### PR TITLE
feat(vus): add vus widget

### DIFF
--- a/lib/helpers/common-components.ts
+++ b/lib/helpers/common-components.ts
@@ -1,0 +1,36 @@
+import { GraphWidget, Metric } from '@aws-cdk/aws-cloudwatch';
+import { Duration } from '@aws-cdk/core';
+
+export function k6Widget(
+  title: string,
+  leftMetrics: Array<Metric>,
+  stacked?: boolean,
+): GraphWidget {
+  return new GraphWidget({
+    title: title,
+    width: 24,
+    height: 6,
+    stacked: stacked ?? true,
+    liveData: true,
+    left: leftMetrics,
+  });
+}
+
+export function k6Metric(
+  name: string,
+  label: string,
+  type = 'timing',
+  statistic = 'avg',
+): Metric {
+  return new Metric({
+    namespace: 'k6',
+    metricName: name,
+    label: label,
+    // @ts-ignore
+    period: Duration.seconds(1),
+    dimensions: {
+      metric_type: type,
+    },
+    statistic: statistic,
+  });
+}

--- a/lib/k6-aws-cloudwatch-cdk.ts
+++ b/lib/k6-aws-cloudwatch-cdk.ts
@@ -1,5 +1,6 @@
 import { Dashboard, TextWidget } from '@aws-cdk/aws-cloudwatch';
 import { Stack, StackProps, Construct } from '@aws-cdk/core';
+import { k6Widget, k6Metric } from './helpers/common-components';
 
 export class K6AwsCloudwatchCdkStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
@@ -11,6 +12,10 @@ export class K6AwsCloudwatchCdkStack extends Stack {
 
     dashboard.addWidgets(
       new TextWidget({ markdown: '# K6', width: 24, height: 1 }),
+    );
+
+    dashboard.addWidgets(
+      k6Widget('Virtual users', [k6Metric('k6_vus', 'Virtual users', 'gauge')]),
     );
   }
 }

--- a/test/__snapshots__/k6-aws-cloudwatch-cdk.snapshot.ts.snap
+++ b/test/__snapshots__/k6-aws-cloudwatch-cdk.snapshot.ts.snap
@@ -5,7 +5,18 @@ Object {
   "Resources": Object {
     "DashCCD7F836": Object {
       "Properties": Object {
-        "DashboardBody": "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"# K6\\"}}]}",
+        "DashboardBody": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{\\"widgets\\":[{\\"type\\":\\"text\\",\\"width\\":24,\\"height\\":1,\\"x\\":0,\\"y\\":0,\\"properties\\":{\\"markdown\\":\\"# K6\\"}},{\\"type\\":\\"metric\\",\\"width\\":24,\\"height\\":6,\\"x\\":0,\\"y\\":1,\\"properties\\":{\\"view\\":\\"timeSeries\\",\\"title\\":\\"Virtual users\\",\\"region\\":\\"",
+              Object {
+                "Ref": "AWS::Region",
+              },
+              "\\",\\"stacked\\":true,\\"metrics\\":[[\\"k6\\",\\"k6_vus\\",\\"metric_type\\",\\"gauge\\",{\\"label\\":\\"Virtual users\\",\\"period\\":1}]],\\"yAxis\\":{},\\"liveData\\":true}}]}",
+            ],
+          ],
+        },
         "DashboardName": "k6-aws-cloudwatch-cdk",
       },
       "Type": "AWS::CloudWatch::Dashboard",

--- a/test/common-components.test.ts
+++ b/test/common-components.test.ts
@@ -1,0 +1,42 @@
+import { GraphWidget, Metric } from '@aws-cdk/aws-cloudwatch';
+import { k6Metric, k6Widget } from '../lib/helpers/common-components';
+
+test('k6Metric function returns Metric', () => {
+  expect(k6Metric('test', 'test')).toBeInstanceOf(Metric);
+});
+
+test('k6Metric function returns metricName', () => {
+  expect(k6Metric('nametest', 'labletest').metricName).toEqual('nametest');
+});
+
+test('k6Metric function returns label', () => {
+  expect(k6Metric('nametest', 'labeltest').label).toEqual('labeltest');
+});
+
+test('k6Metric function returns type', () => {
+  expect(
+    k6Metric('nametest', 'labeltest', 'typetest').dimensions?.metric_type,
+  ).toEqual('typetest');
+});
+
+test('k6Metric function returns statistic', () => {
+  expect(
+    k6Metric('nametest', 'labeltest', 'typetest', 'Sum').statistic,
+  ).toEqual('Sum');
+});
+
+test('k6Metric function returns default type value timing', () => {
+  expect(k6Metric('nametest', 'labeltest').dimensions?.metric_type).toEqual(
+    'timing',
+  );
+});
+
+test('k6Metric function returns default statistic value Average', () => {
+  expect(k6Metric('nametest', 'labeltest').statistic).toEqual('Average');
+});
+
+test('k6Widget function returns GraphWidget', () => {
+  expect(k6Widget('titletest', [k6Metric('foo', 'bar')])).toBeInstanceOf(
+    GraphWidget,
+  );
+});

--- a/test/header-widget.test.ts
+++ b/test/header-widget.test.ts
@@ -5,7 +5,7 @@ import {
   GRID_WIDTH,
   TextWidgetProps,
 } from '@aws-cdk/aws-cloudwatch';
-import { createStack } from './helpers/helpers';
+import { createStack, getDashboardBody } from './helpers/helpers';
 import { Widgets } from './helpers/widgets';
 let k6HeaderProps: TextWidgetProps;
 let k6HeaderWidget: ConcreteWidget;
@@ -15,9 +15,8 @@ beforeEach(() => {
   expect(createStack()).toHaveResourceLike('AWS::CloudWatch::Dashboard', {
     DashboardBody: arn1.capture(),
   });
-  k6HeaderWidget = JSON.parse(arn1.capturedValue).widgets[Widgets.K6Header];
-  k6HeaderProps = JSON.parse(arn1.capturedValue).widgets[Widgets.K6Header]
-    .properties;
+  k6HeaderWidget = getDashboardBody().widgets[Widgets.K6Header];
+  k6HeaderProps = getDashboardBody().widgets[Widgets.K6Header].properties;
 });
 
 test('header TextWidget contains markdown property with value # k6', () => {

--- a/test/vus-widget.test.ts
+++ b/test/vus-widget.test.ts
@@ -1,21 +1,17 @@
 import '@aws-cdk/assert/jest';
-import { Capture } from '@aws-cdk/assert';
 import { GraphWidgetProps, GRID_WIDTH } from '@aws-cdk/aws-cloudwatch';
-import { createStack } from './helpers/helpers';
+import { getDashboardBody } from './helpers/helpers';
 import { Widgets } from './helpers/widgets';
 let vusWidget: GraphWidgetProps;
+let vusWidgetProperties: GraphWidgetProps;
 
 beforeEach(() => {
-  const graphWidget = Capture.anyType();
-  expect(createStack()).toHaveResourceLike('AWS::CloudWatch::Dashboard', {
-    DashboardBody: graphWidget.capture(),
-  });
-  vusWidget = JSON.parse(graphWidget.capturedValue).widgets[Widgets.Vus]
-    .properties;
+  vusWidget = getDashboardBody().widgets[Widgets.Vus];
+  vusWidgetProperties = getDashboardBody().widgets[Widgets.Vus].properties;
 });
 
 test('vus GraphWidget contains property title with value of Virtual Users', () => {
-  expect(vusWidget.title).toEqual('Virtual users');
+  expect(vusWidgetProperties.title).toEqual('Virtual users');
 });
 
 test('vus GraphWidget contains property width with value of GRID_WIDTH', () => {
@@ -27,13 +23,33 @@ test('vus GraphWidget contains property height with value 6', () => {
 });
 
 test('vus GraphWidget contains property stacked with value true', () => {
-  expect(vusWidget.stacked).toEqual(true);
+  expect(vusWidgetProperties.stacked).toEqual(true);
 });
 
 test('vus GraphWidget contains property liveData with value true', () => {
-  expect(vusWidget.liveData).toEqual(true);
+  expect(vusWidgetProperties.liveData).toEqual(true);
 });
 
 test('vus GraphWidget contains property left with 1 metric', () => {
-  expect(vusWidget.left?.length).toEqual(1);
+  expect(
+    getDashboardBody().widgets[Widgets.Vus].properties.metrics.length,
+  ).toEqual(1);
+});
+
+test('vus GraphWidget has metric with name k6_vus', () => {
+  expect(
+    getDashboardBody().widgets[Widgets.Vus].properties.metrics[0][1],
+  ).toEqual('k6_vus');
+});
+
+test('vus GraphWidget has metric with period and value 1', () => {
+  expect(
+    getDashboardBody().widgets[Widgets.Vus].properties.metrics[0][4].period,
+  ).toEqual(1);
+});
+
+test('vus GraphWidget has metric with type gauge', () => {
+  expect(
+    getDashboardBody().widgets[Widgets.Vus].properties.metrics[0][3],
+  ).toEqual('gauge');
 });


### PR DESCRIPTION
add vu widget and common-components.test.ts. Add test coverage
Refactor header-widget.test.ts due to behaviour of cf template based on length of DashBoardBody